### PR TITLE
Fix empty config file handling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1379,7 +1379,15 @@ namespace EnterpriseNVR
                 if (File.Exists(_configPath))
                 {
                     var json = File.ReadAllText(_configPath);
-                    _config = JsonSerializer.Deserialize<NvrConfig>(json) ?? new NvrConfig();
+                    if (string.IsNullOrWhiteSpace(json))
+                    {
+                        _config = new NvrConfig();
+                        _logger.LogWarning("Configuration file empty, using defaults");
+                    }
+                    else
+                    {
+                        _config = JsonSerializer.Deserialize<NvrConfig>(json) ?? new NvrConfig();
+                    }
                 }
                 else
                 {
@@ -1962,7 +1970,11 @@ namespace EnterpriseNVR
             var builder = WebApplication.CreateBuilder(args);
 
             // Load configuration from file so we can read initial settings
-            builder.Configuration.AddJsonFile("/etc/nvr/config.json", optional: true);
+            var configFile = "/etc/nvr/config.json";
+            if (File.Exists(configFile) && new FileInfo(configFile).Length > 0)
+            {
+                builder.Configuration.AddJsonFile(configFile, optional: true);
+            }
             var config = builder.Configuration.Get<NvrConfig>() ?? new NvrConfig();
 
             // Configure services

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Praesidium NVR
 
-Praesidium NVR is an enterprise network video recorder built with the .NET 8 SDK. It records and serves RTSP streams using FFmpeg and exposes a web interface from the `wwwroot` folder. Configuration is loaded from `/etc/nvr/config.json` with sensible defaults when the file is missing.
+Praesidium NVR is an enterprise network video recorder built with the .NET 8 SDK. It records and serves RTSP streams using FFmpeg and exposes a web interface from the `wwwroot` folder. Configuration is loaded from `/etc/nvr/config.json` with sensible defaults when the file is missing or empty.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- handle empty config file when loading at startup
- skip AddJsonFile for an empty config
- document that empty configs get defaults

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e971eed4c83229a047321123a0918